### PR TITLE
Disable forgery protection for StaticFilesController

### DIFF
--- a/app/controllers/pageflow/vr/static_files_controller.rb
+++ b/app/controllers/pageflow/vr/static_files_controller.rb
@@ -3,6 +3,13 @@ module Pageflow
     class StaticFilesController < ActionController::Base
       after_action :allow_iframe, only: :vrview
 
+      # By default Rails only allows XHR requests with js content type
+      # (see docs of
+      # `ActionController::RequestForgeryProtection`). This controller
+      # serves static assets, though. Allow using its endpoint in
+      # `<script>` tags.
+      protect_from_forgery except: :vrview
+
       def vrview
         respond_to do |format|
           format.html


### PR DESCRIPTION
Allow loading `/vrview.js` in a `script` tag. By default, js content
can only be accessed via XHR.

REDMINE-15746